### PR TITLE
add greedy candidate generation with tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.20)
+project(mags_rewrite)
+
+if(APPLE)
+    execute_process(COMMAND xcrun --show-sdk-path OUTPUT_VARIABLE SDK_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+    include_directories(SYSTEM "${SDK_PATH}/usr/include/c++/v1")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(mags_rewrite
+        main.cpp
+        candidate_generation.cpp
+        candidate_generation.h
+        mags_types.h)
+
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/heads/main.zip
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_MakeAvailable(googletest)
+add_executable(mags_tests tests.cpp candidate_generation.cpp)
+target_link_libraries(mags_tests PRIVATE GTest::gtest_main GTest::gtest)

--- a/candidate_generation.cpp
+++ b/candidate_generation.cpp
@@ -1,0 +1,26 @@
+#include "candidate_generation.h"
+
+#include <set>
+
+mags::CandidateSet generate_candidates(mags::Graph const& graph) {
+    mags::CandidateSet candidates;
+    const size_t n = static_cast<mags::NodeID>(graph.size());
+
+    for (mags::NodeID u = 0; u < n; u++) {
+        std::set<mags::NodeID> potential_candidates;
+
+        for (const mags::NodeID v_1hop : graph[u]) {
+            if (v_1hop > u) potential_candidates.insert(v_1hop);
+
+            for (mags::NodeID v_2hop : graph[v_1hop]) {
+                if (v_2hop > u) potential_candidates.insert(v_2hop);
+            }
+        }
+
+        for (mags::NodeID v : potential_candidates) {
+            candidates.emplace_back(u, v);
+        }
+    }
+
+    return candidates;
+}

--- a/candidate_generation.h
+++ b/candidate_generation.h
@@ -1,0 +1,7 @@
+#ifndef MAGS_REWRITE_CANDIDATE_GENERATION_H
+#define MAGS_REWRITE_CANDIDATE_GENERATION_H
+#include "mags_types.h"
+
+mags::CandidateSet generate_candidates(mags::Graph const& graph);
+
+#endif //MAGS_REWRITE_CANDIDATE_GENERATION_H

--- a/mags_types.h
+++ b/mags_types.h
@@ -1,0 +1,14 @@
+#ifndef MAGS_REWRITE_MAGS_TYPES_H
+#define MAGS_REWRITE_MAGS_TYPES_H
+
+#include <utility>
+#include <vector>
+
+namespace mags {
+    using NodeID = int;
+    using CandidatePair = std::pair<NodeID, NodeID>;
+    using CandidateSet = std::vector<CandidatePair>;
+    using Graph = std::vector<std::vector<NodeID>>;
+}
+
+#endif //MAGS_REWRITE_MAGS_TYPES_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Starting Mags rewrite test..." << std::endl;
+
+    return 0;
+}

--- a/tests.cpp
+++ b/tests.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+#include "candidate_generation.h"
+
+bool contains_pair(const mags::CandidateSet& cs, int u, int v) {
+    const mags::CandidatePair target = (u < v) ? std::make_pair(u, v) : std::make_pair(v, u);
+    return std::find(cs.begin(), cs.end(), target) != cs.end();
+}
+
+TEST(GreedyCandidateGeneration, DiamondGraphCompleteness) {
+    // Diamond Graph
+    mags::Graph graph(4);
+    graph[0] = {1, 2};
+    graph[1] = {0, 3};
+    graph[2] = {0, 3};
+    graph[3] = {1, 2};
+
+    const auto candidates = generate_candidates(graph);
+
+    // All combinations should be found in this tiny dense graph
+    // (0,1), (0,2), (0,3), (1,2), (1,3), (2,3) = 6 pairs
+    EXPECT_EQ(candidates.size(), 6);
+
+    // Verify specific 2-hop pairs are found
+    EXPECT_TRUE(contains_pair(candidates, 0, 3)) << "Nodes 0 and 3 share neighbors 1 and 2";
+    EXPECT_TRUE(contains_pair(candidates, 1, 2)) << "Nodes 1 and 2 share neighbors 0 and 3";
+
+    // 3. Verify 1-hop pairs are found
+    EXPECT_TRUE(contains_pair(candidates, 0, 1));
+    EXPECT_TRUE(contains_pair(candidates, 0, 2));
+    EXPECT_TRUE(contains_pair(candidates, 2, 3));
+    EXPECT_TRUE(contains_pair(candidates, 1, 3));
+}
+
+TEST(GreedyCandidateGeneration, NoInvalidPairs) {
+    mags::Graph graph(3);
+    graph[0] = {1};
+    graph[1] = {0, 2};
+    graph[2] = {1};
+
+    const auto candidates = generate_candidates(graph);
+
+    for (const auto& pair : candidates) {
+        EXPECT_LT(pair.first, pair.second) << "Self-loop or reversed pair detected";
+
+        // Ensure IDs are within graph bounds
+        EXPECT_GE(pair.first, 0);
+        EXPECT_LT(pair.second, 3);
+    }
+}
+
+TEST(GreedyCandidateGeneration, TriangleNoDuplicates) {
+    mags::Graph graph(3);
+    graph[0] = {1, 2}; graph[1] = {0, 2}; graph[2] = {0, 1};
+    const auto candidates = generate_candidates(graph);
+    // Should be exactly 3 pairs: (0,1), (0,2), (1,2)
+    EXPECT_EQ(candidates.size(), 3);
+}
+
+TEST(GreedyCandidateGeneration, IsolatedNode) {
+    mags::Graph graph(5);
+    graph[0] = {1}; graph[1] = {0}; // Components 0-1
+    // Node 2, 3, 4 are isolated
+    const auto candidates = generate_candidates(graph);
+    EXPECT_EQ(candidates.size(), 1); // Only (0,1)
+}
+
+TEST(GreedyCandidateGeneration, StarGraph) {
+    mags::Graph graph(4);
+    graph[0] = {1, 2, 3}; graph[1] = {0}; graph[2] = {0}; graph[3] = {0};
+    const auto candidates = generate_candidates(graph);
+    // 1-hop: (0,1), (0,2), (0,3)
+    // 2-hop: (1,2), (1,3), (2,3) -> Total 6
+    EXPECT_EQ(candidates.size(), 6);
+}


### PR DESCRIPTION
Implement 2-hop search logic. This follows the greedy paradigm from Navlakha et al., identfiying all 1-hop and 2-hop neighbor pairs as candidates for merging. Include GTests for Diamond and Star graph structures.